### PR TITLE
Rename Announcements to notifications

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -184,7 +184,7 @@
             </div>
 
             <script id="notificationTemplate" type="text/x-jsrender">
-                                       <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}"  data-parentFeedid="{{:Parent_Feed_If_Not_A_Post || Parent_Feed_ID}}" data-targetid="{{:Parent_Feed_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
+                                       <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-notification="{{:ID}}"  data-parentFeedid="{{:Parent_Feed_If_Not_A_Post || Parent_Feed_ID}}" data-targetid="{{:Parent_Feed_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
                                         <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
                                         <div class="flex-1">
                                           <div class="p3 text-[var(--color-black)]">{{:Title}}</div>
@@ -719,7 +719,7 @@
               <div x-show="openScheduleDatePicker" @click.outside="openScheduleDatePicker = false"
                 class="absolute mt-2 bottom-[2rem] right-0 max-[702px]:-right-[50%] w-64 bg-white shadow-lg rounded border p-2 z-50"
                 x-transition>
-                <div for="datePicker" class="block h3 text-black mb-2">Schedule Announcement</div>
+                <div for="datePicker" class="block h3 text-black mb-2">Schedule Notification</div>
                 <div class="flex flex-col ">
                   <div class="cursor-pointer hover:bg-[var(--color-primary-shade)] rounded p-2 p3 text-black"
                     data-sort="Latest" @click="

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -642,7 +642,7 @@
           </div>
 
           <script id="notificationTemplate" type="text/x-jsrender">
-                                           <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}"  data-parentFeedid="{{:Parent_Feed_If_Not_A_Post || Parent_Feed_ID}}" data-targetid="{{:Parent_Feed_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
+                                           <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-notification="{{:ID}}"  data-parentFeedid="{{:Parent_Feed_If_Not_A_Post || Parent_Feed_ID}}" data-targetid="{{:Parent_Feed_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
                                             <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
                                             <div class="flex-1">
                                               <div class="p3 text-[var(--color-black)]">{{:Title}}</div>
@@ -790,7 +790,7 @@
   </div>
 
   <script id="notificationTemplate" type="text/x-jsrender">
-    <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-announcement="{{:ID}}" data-parentFeedid="{{:Parent_Feed_If_Not_A_Post || Parent_Feed_ID}}" data-targetid="{{:Parent_Feed_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
+    <div class="notification {{if Is_Read}}read{{else}}unread{{/if}} cursor-pointer flex items-start gap-3 rounded-lg p-3 hover:bg-gray-100" data-notification="{{:ID}}" data-parentFeedid="{{:Parent_Feed_If_Not_A_Post || Parent_Feed_ID}}" data-targetid="{{:Parent_Feed_ID}}" data-notiftype="{{:Notification_Type}}" @click="modalForPostOpen=true">
       <i class="fa-solid fa-file-alt mt-1 text-lg text-indigo-500"></i>
       <div class="flex-1">
         <div class="p3 text-[var(--color-black)]">{{:Title}}</div>

--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -261,10 +261,10 @@ mutation updateFeedPost(
 `;
 
 export const CREATE_NOTIFICATION = `
-mutation createAnnouncements(
-  $payload: [AnnouncementCreateInput] = null
+mutation createNotifications(
+  $payload: [NotificationCreateInput] = null
 ) {
-  createAnnouncements(payload: $payload) {
+  createNotifications(payload: $payload) {
     parent_feed_id
     notified_contact_id
     parent_feed_if_not_a_post

--- a/src/notifications.js
+++ b/src/notifications.js
@@ -241,16 +241,16 @@ export function initNotificationEvents() {
       console.log("Marking all notifications as read");
       const elements = [];
       targetContainers.forEach((c) => {
-        elements.push(...c.querySelectorAll("[data-announcement].unread"));
+        elements.push(...c.querySelectorAll("[data-notification].unread"));
       });
-      ids = elements.map((el) => el.getAttribute("data-announcement"));
+      ids = elements.map((el) => el.getAttribute("data-notification"));
     } else {
       const unreadElements = document.querySelectorAll(".unread");
       for (const el of unreadElements) {
         if (el.contains(e.target)) {
-          const announcementId = el.getAttribute("data-announcement");
-          if (!announcementId) return;
-          ids = [announcementId];
+          const notificationId = el.getAttribute("data-notification");
+          if (!notificationId) return;
+          ids = [notificationId];
           break;
         }
       }
@@ -262,9 +262,9 @@ export function initNotificationEvents() {
       payload: { is_read: true },
     };
 
-    const UPDATE_ANNOUNCEMENT = `
-      mutation updateAnnouncements($payload: AnnouncementUpdateInput = null) {
-        updateAnnouncements(query: [{ whereIn: { id: [${ids.join(",")}] } }], payload: $payload) {
+    const UPDATE_NOTIFICATION = `
+      mutation updateNotifications($payload: NotificationUpdateInput = null) {
+        updateNotifications(query: [{ whereIn: { id: [${ids.join(",")}] } }], payload: $payload) {
           is_read
         }
       }
@@ -277,18 +277,18 @@ export function initNotificationEvents() {
       } else if (markAllPage){
         $("#allNotificationInPage")?.click();
       }
-      await fetchGraphQL(UPDATE_ANNOUNCEMENT, variables, UPDATE_ANNOUNCEMENT);
+      await fetchGraphQL(UPDATE_NOTIFICATION, variables, UPDATE_NOTIFICATION);
 
       if (markAll) {
         targetContainers.forEach((c) => {
-          c.querySelectorAll("[data-announcement].unread").forEach((el) => {
+          c.querySelectorAll("[data-notification].unread").forEach((el) => {
             el.classList.remove("unread");
             el.classList.add("read");
           });
         });
       } else {
         document.querySelectorAll(".unread").forEach((el) => {
-          if (ids.includes(el.getAttribute("data-announcement"))) {
+          if (ids.includes(el.getAttribute("data-notification"))) {
             el.classList.remove("unread");
             el.classList.add("read");
           }
@@ -296,7 +296,7 @@ export function initNotificationEvents() {
       }
       applyNotificationFilters();
     } catch (error) {
-      console.error("Error marking announcement(s) as read:", error);
+      console.error("Error marking notification(s) as read:", error);
     } finally {
       if (markAllTop) {
         $(".notificationsLoader").removeClass("flex").addClass("hidden");


### PR DESCRIPTION
## Summary
- rename all occurrences of Announcements to notifications

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_686666317328832198e27cadb44e3ac2