### PR TITLE
Add dynamic account name support

### DIFF
--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -1,10 +1,14 @@
-import { userContactIds, GLOBAL_AUTHOR_ID } from "../config.js";
+import {
+  userContactIds,
+  GLOBAL_AUTHOR_ID,
+  ACCOUNT_NAME,
+} from "../config.js";
 import { GLOBAL_PAGE_TAG } from "../config.js";
 import { notificationStore } from "../config.js";
 
 export const FETCH_CONTACTS_QUERY = `
-query calcContacts {
-  calcContacts(
+query feedContacts {
+  feedContacts: calcContacts(
     query: [
       {
         where: {
@@ -73,7 +77,7 @@ export const CREATE_FEED_POST_MUTATION = `
 `;
 
 export const DELETE_FEED_POST_MUTATION = `
-  mutation deleteFeed($id: EventmxFeedID) {
+  mutation deleteFeed($id: ${ACCOUNT_NAME}FeedID) {
     deleteFeed(query: [{ where: { id: $id } }]) {
       id
     }
@@ -81,7 +85,7 @@ export const DELETE_FEED_POST_MUTATION = `
 `;
 
 export const UPDATE_FEED_POST_MUTATION = `
-mutation updateFeedPost($id: EventmxFeedID, $payload: FeedPostUpdateInput = null) {
+mutation updateFeedPost($id: ${ACCOUNT_NAME}FeedID, $payload: FeedPostUpdateInput = null) {
   updateFeedPost(query: [{ where: { id: $id } }], payload: $payload) {
     featured_feed
     disable_new_comments
@@ -182,7 +186,7 @@ mutation createOBookmarkingContactBookmarkedFeed($payload: OBookmarkingContactBo
 
 export const DELETE_BOOKMARK_MUTATION = `
 mutation deleteOBookmarkingContactBookmarkedFeed(
-  $id: EventmxOBookmarkingContactBookmarkedFeedID
+  $id: ${ACCOUNT_NAME}OBookmarkingContactBookmarkedFeedID
 ) {
   deleteOBookmarkingContactBookmarkedFeed(
     query: [{ where: { id: $id } }]
@@ -205,7 +209,7 @@ mutation createOFeedReactorReactedtoFeed($payload: OFeedReactorReactedtoFeedCrea
 
 export const DELETE_REACTION_MUTATION = `
 mutation deleteOFeedReactorReactedtoFeed(
-  $id: EventmxOFeedReactorReactedtoFeedID
+  $id: ${ACCOUNT_NAME}OFeedReactorReactedtoFeedID
 ) {
   deleteOFeedReactorReactedtoFeed(query: [{ where: { id: $id } }]) {
     id
@@ -214,8 +218,8 @@ mutation deleteOFeedReactorReactedtoFeed(
 `;
 
 export const GET_CONTACTS_BY_TAGS = `
-query calcContacts($id: EventmxContactID, $name: TextScalar) {
-  calcContacts(
+query feedContacts($id: ${ACCOUNT_NAME}ContactID, $name: TextScalar) {
+  feedContacts: calcContacts(
     query: [
       { where: { id: $id } }
       {
@@ -233,8 +237,8 @@ query calcContacts($id: EventmxContactID, $name: TextScalar) {
 `;
 
 export const GET_CONTACTS_FOR_MODAL = `
-query calcContacts {
-  calcContacts(
+query feedContacts {
+  feedContacts: calcContacts(
     query: [
       { whereIn: { id: [${userContactIds}], _OPERATOR_: in } }
     ]
@@ -343,8 +347,8 @@ export function GET_NOTIFICATIONS() {
 
   return `
   subscription subscribeToNotifications(
-    $author_id: EventmxContactID 
-    $notified_contact_id: EventmxContactID 
+    $author_id: ${ACCOUNT_NAME}ContactID
+    $notified_contact_id: ${ACCOUNT_NAME}ContactID
   ) {
     subscribeToNotifications(
       query: [
@@ -430,7 +434,7 @@ export function GET_NOTIFICATIONS() {
 }
 
 export const GET__CONTACTS_NOTIFICATION_PREFERENCEE = `
-query getContact($id: EventmxContactID) {
+query getContact($id: ${ACCOUNT_NAME}ContactID) {
   getContact(query: [{ where: { id: $id } }]) {
     Turn_Off_All_Notifications: turn_off_all_notifications
     Notify_me_of_all_Posts: notify_me_of_all_posts
@@ -441,7 +445,7 @@ query getContact($id: EventmxContactID) {
 `;
 export const UPDATE_CONTACT_NOTIFICATION_PREFERENCE = `
 mutation updateContact(
-  $id: EventmxContactID
+  $id: ${ACCOUNT_NAME}ContactID
   $payload: ContactUpdateInput = null
 ) {
   updateContact(
@@ -457,7 +461,7 @@ mutation updateContact(
 `;
 export const GET_SINGLE_POST_SUBSCRIPTION = `
 subscription subscribeToFeed(
-  $id: EventmxFeedID
+  $id: ${ACCOUNT_NAME}FeedID
 ) {
   subscribeToFeed(
     query: [{ where: { id: $id } }]

--- a/src/config.js
+++ b/src/config.js
@@ -36,11 +36,13 @@ export const MAX_BACKOFF = 30000;
 export const INACTIVITY_MS = 10 * 60 * 1000; 
 export let GLOBAL_AUTHOR_ID = '';
 export let GLOBAL_AUTHOR_DISPLAY_NAME = "Eventmx";
-export let GLOBAL_PAGE_TAG ="Demo_Feed";
-export function setGlobals(authorId, pageTag, displayName) {
+export let GLOBAL_PAGE_TAG = "Demo_Feed";
+export let ACCOUNT_NAME = cfg.ACCOUNT_NAME || env.ACCOUNT_NAME || "Eventmx";
+export function setGlobals(authorId, pageTag, displayName, accountName = ACCOUNT_NAME) {
   GLOBAL_AUTHOR_ID = Number(authorId);
-  GLOBAL_PAGE_TAG = "Demo_Feed";
+  GLOBAL_PAGE_TAG = pageTag;
   GLOBAL_AUTHOR_DISPLAY_NAME = displayName;
+  ACCOUNT_NAME = accountName;
 }
 export const DEFAULT_AVATAR =
   "https://files.ontraport.com/media/b0456fe87439430680b173369cc54cea.php03bzcx?Expires=4895186056&Signature=fw-mkSjms67rj5eIsiDF9QfHb4EAe29jfz~yn3XT0--8jLdK4OGkxWBZR9YHSh26ZAp5EHj~6g5CUUncgjztHHKU9c9ymvZYfSbPO9JGht~ZJnr2Gwmp6vsvIpYvE1pEywTeoigeyClFm1dHrS7VakQk9uYac4Sw0suU4MpRGYQPFB6w3HUw-eO5TvaOLabtuSlgdyGRie6Ve0R7kzU76uXDvlhhWGMZ7alNCTdS7txSgUOT8oL9pJP832UsasK4~M~Na0ku1oY-8a7GcvvVv6j7yE0V0COB9OP0FbC8z7eSdZ8r7avFK~f9Wl0SEfS6MkPQR2YwWjr55bbJJhZnZA__&Key-Pair-Id=APKAJVAAMVW6XQYWSTNA";

--- a/src/domEvents.js
+++ b/src/domEvents.js
@@ -48,7 +48,7 @@ function renderContacts(list, containerId) {
 export async function loadModalContacts() {
   try {
     const res = await fetchGraphQL(GET_CONTACTS_FOR_MODAL);
-    const allContacts = res?.data?.calcContacts || [];
+    const allContacts = res?.data?.feedContacts || [];
     const subscriberContacts = allContacts.filter(
       (c) => c.TagName === `${GLOBAL_PAGE_TAG}_Subscriber`
     );

--- a/src/features/posts/user.js
+++ b/src/features/posts/user.js
@@ -14,7 +14,7 @@ export async function ensureCurrentUser() {
   }
   try {
     const res = await fetchGraphQL(FETCH_CONTACTS_QUERY);
-    const contacts = res?.data?.calcContacts || [];
+    const contacts = res?.data?.feedContacts || [];
     const current = contacts.find((c) => c.Contact_ID === GLOBAL_AUTHOR_ID);
     if (current) {
       state.currentUser = {

--- a/src/main.js
+++ b/src/main.js
@@ -67,7 +67,7 @@ function startApp(tagName, contactId, displayName) {
   }
   fetchGraphQL(FETCH_CONTACTS_QUERY)
     .then((res) => {
-      const contacts = res.data.calcContacts;
+      const contacts = res.data.feedContacts;
       state.allContacts = contacts.map((c) => c.Contact_ID);
       tribute.collection[0].values = contacts.map((c) => ({
         key: c.Display_Name || "Anonymous",
@@ -103,7 +103,7 @@ function startApp(tagName, contactId, displayName) {
     name: contactTagForQuery,
   })
     .then((res) => {
-      const result = res?.data?.calcContacts;
+      const result = res?.data?.feedContacts;
       if (Array.isArray(result) && result.length > 0) {
         setContactIncludedInTag(true);
         if (hasFeedRoot) {

--- a/src/notifications-only.js
+++ b/src/notifications-only.js
@@ -62,7 +62,7 @@ function getNotificationPreferences(contactId) {
 function fetchContactsAndCurrentUser(contactId) {
   return fetchGraphQL(FETCH_CONTACTS_QUERY)
     .then((res) => {
-      const contacts = res?.data?.calcContacts || [];
+      const contacts = res?.data?.feedContacts || [];
       state.allContacts = contacts.map((c) => c.Contact_ID);
       tribute.collection[0].values = contacts.map((c) => ({
         key: c.Display_Name || "Anonymous",


### PR DESCRIPTION
## Summary
- allow setting `ACCOUNT_NAME` in `config.js`
- alias contacts query as `feedContacts`
- replace hardcoded `Eventmx` types with `${ACCOUNT_NAME}`
- update DOM handlers to use `feedContacts`

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_68676a93efac8321bbab99bef682e7cc