### PR TITLE
Centralize GLOBAL_PAGE_TAG

### DIFF
--- a/public/notifications.html
+++ b/public/notifications.html
@@ -800,7 +800,8 @@
   </script>
 
   <script type="module">
-    import { setGlobals, GLOBAL_PAGE_TAG, GLOBAL_AUTHOR_DISPLAY_NAME } from '../src/config.js';
+    import { setGlobals, GLOBAL_AUTHOR_DISPLAY_NAME } from '../src/config.js';
+    import { GLOBAL_PAGE_TAG } from '../src/tag.js';
     setGlobals(40, GLOBAL_PAGE_TAG, GLOBAL_AUTHOR_DISPLAY_NAME);
   </script>
   <script type="module" src="../src/notifications-only.js"></script>

--- a/src/api/queries.js
+++ b/src/api/queries.js
@@ -2,7 +2,7 @@ import {
   userContactIds,
   GLOBAL_AUTHOR_ID,
 } from "../config.js";
-import { GLOBAL_PAGE_TAG } from "../config.js";
+import { GLOBAL_PAGE_TAG } from "../tag.js";
 import { notificationStore } from "../config.js";
 
 export const FETCH_CONTACTS_QUERY = `

--- a/src/config.js
+++ b/src/config.js
@@ -4,6 +4,7 @@
 window.APP_CONFIG = {};
 
 import credentials from "./credentials.js";
+import { GLOBAL_PAGE_TAG } from "./tag.js";
 
 export const env =
   credentials ||
@@ -36,11 +37,12 @@ export const MAX_BACKOFF = 30000;
 export const INACTIVITY_MS = 10 * 60 * 1000; 
 export let GLOBAL_AUTHOR_ID = '';
 export let GLOBAL_AUTHOR_DISPLAY_NAME = "Eventmx";
-export let GLOBAL_PAGE_TAG = "Demo_Feed";
 //export let ACCOUNT_NAME = cfg.ACCOUNT_NAME || env.ACCOUNT_NAME || "Eventmx";
 export function setGlobals(authorId, pageTag, displayName, accountName = ACCOUNT_NAME) {
   GLOBAL_AUTHOR_ID = Number(authorId);
-  GLOBAL_PAGE_TAG = pageTag;
+  if (typeof window !== "undefined") {
+    window.GLOBAL_PAGE_TAG = pageTag;
+  }
   GLOBAL_AUTHOR_DISPLAY_NAME = displayName;
   ACCOUNT_NAME = accountName;
 }

--- a/src/domEvents.js
+++ b/src/domEvents.js
@@ -4,7 +4,7 @@ import { fetchGraphQL } from "./api/fetch.js";
 import { showToast } from "./ui/toast.js";
 import { disableBodyScroll, enableBodyScroll } from "./utils/bodyScroll.js";
 import { setPendingFile, setFileTypeCheck } from "./features/uploads/handlers.js";
-import { GLOBAL_PAGE_TAG } from "./config.js";
+import { GLOBAL_PAGE_TAG } from "./tag.js";
 
 function renderContacts(list, containerId) {
   const container = document.getElementById(containerId);

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -2,11 +2,11 @@ import { fetchGraphQL } from "../../api/fetch.js";
 import { CREATE_FEED_POST_MUTATION } from "../../api/queries.js";
 import {
   state,
-  GLOBAL_PAGE_TAG,
   GLOBAL_AUTHOR_ID,
   GLOBAL_AUTHOR_DISPLAY_NAME,
   DEFAULT_AVATAR,
 } from "../../config.js";
+import { GLOBAL_PAGE_TAG } from "../../tag.js";
 import { findNode, buildTree, mapItem } from "../../ui/render.js";
 import {
   pendingFile,

--- a/src/main.js
+++ b/src/main.js
@@ -1,5 +1,6 @@
 import '../src/initAlpine.js';
-import { state, notificationStore, GLOBAL_AUTHOR_ID, DEFAULT_AVATAR, GLOBAL_PAGE_TAG } from "./config.js";
+import { state, notificationStore, GLOBAL_AUTHOR_ID, DEFAULT_AVATAR } from "./config.js";
+import { GLOBAL_PAGE_TAG } from "./tag.js";
 import { setGlobals } from "./config.js";
 import { FETCH_CONTACTS_QUERY, GET_CONTACTS_BY_TAGS, GET__CONTACTS_NOTIFICATION_PREFERENCEE, UPDATE_CONTACT_NOTIFICATION_PREFERENCE } from "./api/queries.js";
 import { pauseAllPlayers } from "./utils/plyr.js";

--- a/src/tag.js
+++ b/src/tag.js
@@ -1,0 +1,14 @@
+let GLOBAL_PAGE_TAG = "Demo_Feed";
+
+if (typeof window !== "undefined") {
+  Object.defineProperty(window, "GLOBAL_PAGE_TAG", {
+    get() {
+      return GLOBAL_PAGE_TAG;
+    },
+    set(value) {
+      GLOBAL_PAGE_TAG = value;
+    },
+  });
+}
+
+export { GLOBAL_PAGE_TAG };

--- a/src/ws.js
+++ b/src/ws.js
@@ -6,8 +6,8 @@ import {
   KEEPALIVE_MS,
   MAX_BACKOFF,
   INACTIVITY_MS,
-  GLOBAL_PAGE_TAG
 } from "./config.js";
+import { GLOBAL_PAGE_TAG } from "./tag.js";
 import { SUBSCRIBE_FEED_POSTS } from "./api/queries.js";
 import { buildTree } from "./ui/render.js";
 import { mergeLists } from "./utils/merge.js";


### PR DESCRIPTION
## Summary
- move `GLOBAL_PAGE_TAG` to a dedicated `tag.js`
- remove the setter function and expose a global variable via `window`
- update `setGlobals` to update this global variable

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_68677476090c83219299847152153bfa