### PR TITLE
Add active highlight for rich text buttons

### DIFF
--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -182,6 +182,12 @@ button:not(.file-preview button):hover {
   display: flex;
   gap: 0.25rem;
 }
+.toolbar button.active {
+  background-color: var(--color-primary-shade);
+}
+.toolbar button.active path {
+  fill: var(--color-primary);
+}
 
 
 .emoji-wrapper {

--- a/public/styles/styleOp.css
+++ b/public/styles/styleOp.css
@@ -231,6 +231,12 @@ button:not(.file-preview button):hover {
   display: flex;
   gap: 0.25rem;
 }
+.toolbar button.active {
+  background-color: var(--color-primary-shade);
+}
+.toolbar button.active path {
+  fill: var(--color-primary);
+}
 
 .emoji-wrapper {
   width: 100%;

--- a/src/utils/richText.js
+++ b/src/utils/richText.js
@@ -18,6 +18,7 @@ export function initRichText() {
       }
     } else {
       applyFormat(cmd, editor);
+      updateToolbar(editor);
     }
   });
 }
@@ -29,6 +30,16 @@ function applyFormat(cmd, editor, value) {
   } else {
     document.execCommand(cmd, false, null);
   }
+}
+function updateToolbar(editor) {
+  const toolbar = $(editor)
+    .closest('.comment-form, #post-creation-form')
+    .find('.toolbar');
+  toolbar.find('button').each(function () {
+    const cmd = $(this).data('cmd');
+    if (!cmd || cmd === "link") return;
+    $(this).toggleClass('active', document.queryCommandState(cmd));
+  });
 }
 $(document).on('input', '.editor', function () {
   const html = this.innerHTML.trim().toLowerCase();
@@ -42,4 +53,5 @@ $(document).on('input', '.editor', function () {
     sel.removeAllRanges();
     sel.addRange(range);
   }
+  updateToolbar(this);
 });


### PR DESCRIPTION
## Summary
- highlight active toolbar buttons
- update toolbar state when formatting buttons are clicked or editor updates

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_686b9e5233208321aaa6beb152eeff2e