### PR TITLE
Fix iOS rich text selection

### DIFF
--- a/src/utils/richText.js
+++ b/src/utils/richText.js
@@ -1,3 +1,5 @@
+import { restoreSelection, saveSelection } from './caret.js';
+
 export function initRichText() {
   $(document).on('click', '.toolbar button', function (e) {
     e.preventDefault();
@@ -7,6 +9,7 @@ export function initRichText() {
       .find('.editor')[0];
     if (!editor) return;
     editor.focus();
+    restoreSelection(editor);
     if (cmd === 'link') {
       let url = prompt('Enter URL');
       if (url) {
@@ -19,6 +22,7 @@ export function initRichText() {
     } else {
       applyFormat(cmd, editor);
       updateToolbar(editor);
+      saveSelection();
     }
   });
 }


### PR DESCRIPTION
## Summary
- restore cursor position before applying toolbar commands
- persist selection after formatting

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_686babf1f9a083219d6374fbdf2e2fa2