### PR TITLE
Add Quill editor

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -30,6 +30,8 @@
   <script src="https://cdn.jsdelivr.net/npm/jsrender/jsrender.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/tributejs@5.1.3/dist/tribute.min.js"></script>
+  <link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet" />
+  <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
   <script src="../src/keys.js"></script>
 </head>

--- a/public/notifications.html
+++ b/public/notifications.html
@@ -25,6 +25,8 @@
   <script src="https://cdn.jsdelivr.net/npm/jsrender/jsrender.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.0.2/dist/purify.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/tributejs@5.1.3/dist/tribute.min.js"></script>
+  <link href="https://cdn.quilljs.com/1.3.7/quill.snow.css" rel="stylesheet" />
+  <script src="https://cdn.quilljs.com/1.3.7/quill.min.js"></script>
   <script type="module" src="../src/initAlpine.js"></script>
   <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
 </head>

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -380,6 +380,9 @@ button:not(.file-preview button):hover {
 .editor {
   font-size: 12px !important;
 }
+.ql-editor {
+  padding: 0;
+}
 
 /* Skeleton loader styles */
 .skeleton-item {

--- a/src/domEvents.js
+++ b/src/domEvents.js
@@ -87,7 +87,9 @@ export async function loadModalContacts() {
 
 function resetCreatePostModal() {
   const editor = document.getElementById("post-editor");
-  if (editor) editor.innerHTML = "";
+  if (editor) {
+    editor.__quill ? editor.__quill.setText('') : (editor.innerHTML = "");
+  }
   const fileInput = document.getElementById("file-input");
   if (fileInput) {
     if (fileInput.filepond) {
@@ -113,7 +115,12 @@ export function setupCreatePostModal() {
       modal.classList.remove("hidden");
       modal.classList.add("show");
       disableBodyScroll();
-      document.getElementById("post-editor").focus();
+      const pe = document.getElementById("post-editor");
+      if (pe.__quill) {
+        pe.__quill.focus();
+      } else {
+        pe.focus();
+      }
     });
   }
 

--- a/src/features/posts/actions.js
+++ b/src/features/posts/actions.js
@@ -62,8 +62,11 @@ export async function createFeedToSubmit(
     ? $(formWrapper).find('#submitFeedPost')
     : $(this);
   const inModal = Boolean(formWrapper?.closest('#modalFeedRoot'));
-  const editor = $(`.${formElementId} .editor`);
-  const htmlContent = editor.html().trim();
+  const editor = $(`.${formElementId} .ql-editor.editor`);
+  const quillInstance = editor[0]?.__quill;
+  const htmlContent = quillInstance
+    ? quillInstance.root.innerHTML.trim()
+    : editor.html().trim();
   if (!htmlContent && !pendingFile) {
     alert("Please enter some content or upload a file.");
     return null;
@@ -248,7 +251,11 @@ export async function createFeedToSubmit(
       }
     }
     if (scheduledDateUnix) scheduledDateUnix.textContent = '';
-    editor.html("");
+    if (quillInstance) {
+      quillInstance.setText('');
+    } else {
+      editor.html("");
+    }
     setPendingFile(null);
     setFileTypeCheck("");
     $("#file-input").val("");

--- a/src/features/posts/comments.js
+++ b/src/features/posts/comments.js
@@ -3,6 +3,7 @@ import { findNode } from "../../ui/render.js";
 import { toolbarDesign } from "../../ui/emoji.js";
 import { moveCursorToEnd } from "../../utils/caret.js";
 import { tribute } from "../../utils/tribute.js";
+import { initQuillEditor } from "../../utils/quillSetup.js";
 import { initFilePond } from "../../utils/filePond.js";
 import { applyFilterAndRender } from "./filters.js";
 import { rerenderModal, getModalTree } from "./postModal.js";
@@ -86,13 +87,15 @@ export function initCommentHandlers() {
     if (inserted.length) {
       const editorEl = inserted.find(".editor")[0];
       if (editorEl) {
-        tribute.attach(editorEl);
+        const quill = initQuillEditor(editorEl);
+        const target = quill ? quill.root : editorEl;
+        tribute.attach(target);
       }
       container.find(".children").addClass("visible");
       requestAnimationFrame(() => {
         inserted[0].scrollIntoView({ behavior: "smooth", block: "center" });
         if (editorEl) {
-          moveCursorToEnd(editorEl);
+          moveCursorToEnd(editorEl.__quill ? editorEl.__quill.root : editorEl);
         }
       });
     }

--- a/src/main.js
+++ b/src/main.js
@@ -66,7 +66,8 @@ function startApp(tagName, contactId, displayName) {
   const hasNotifOptions = document.getElementById("notificationOptionsContainer");
 
   if (postEditor) {
-    tribute.attach(postEditor);
+    const target = postEditor.querySelector('.ql-editor') || postEditor;
+    tribute.attach(target);
   }
   fetchGraphQL(FETCH_CONTACTS_QUERY)
     .then((res) => {

--- a/src/ui/emoji.js
+++ b/src/ui/emoji.js
@@ -151,15 +151,24 @@ export function initEmojiHandlers() {
 }
 
 function insertEmoji(editor, emoji) {
-  editor.focus();
-  restoreSelection(editor);
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0) return;
-  const range = sel.getRangeAt(0);
-  range.deleteContents();
-  range.insertNode(document.createTextNode(emoji));
-  range.collapse(false);
-  sel.removeAllRanges();
-  sel.addRange(range);
-  saveSelection();
+  if (editor.__quill) {
+    const quill = editor.__quill;
+    quill.focus();
+    const range = quill.getSelection(true);
+    const index = range ? range.index : quill.getLength();
+    quill.insertText(index, emoji, 'user');
+    quill.setSelection(index + emoji.length, 0, 'user');
+  } else {
+    editor.focus();
+    restoreSelection(editor);
+    const sel = window.getSelection();
+    if (!sel || sel.rangeCount === 0) return;
+    const range = sel.getRangeAt(0);
+    range.deleteContents();
+    range.insertNode(document.createTextNode(emoji));
+    range.collapse(false);
+    sel.removeAllRanges();
+    sel.addRange(range);
+    saveSelection();
+  }
 }

--- a/src/utils/caret.js
+++ b/src/utils/caret.js
@@ -1,28 +1,50 @@
-let savedRange = null;
+let saved = null;
 
 export function saveSelection() {
+  const active = document.activeElement;
+  if (active && active.__quill) {
+    const range = active.__quill.getSelection();
+    if (range) {
+      saved = { type: 'quill', quill: active.__quill, range };
+      return;
+    }
+  }
   const sel = window.getSelection();
   if (sel && sel.rangeCount > 0) {
-    savedRange = sel.getRangeAt(0).cloneRange();
+    saved = { type: 'dom', range: sel.getRangeAt(0).cloneRange() };
   }
 }
 
 export function restoreSelection(el) {
-  if (!savedRange) return;
-  const sel = window.getSelection();
-  if (el.contains(savedRange.startContainer)) {
-    sel.removeAllRanges();
-    sel.addRange(savedRange);
+  if (!saved) return;
+  if (saved.type === 'quill' && el.__quill === saved.quill) {
+    saved.quill.setSelection(saved.range);
+    return;
+  }
+  if (saved.type === 'dom') {
+    const sel = window.getSelection();
+    if (el.contains(saved.range.startContainer)) {
+      sel.removeAllRanges();
+      sel.addRange(saved.range);
+    }
   }
 }
 
 export function moveCursorToEnd(el) {
-  const range = document.createRange();
-  range.selectNodeContents(el);
-  range.collapse(false);
-  const sel = window.getSelection();
-  sel.removeAllRanges();
-  sel.addRange(range);
-  el.focus();
-  savedRange = range.cloneRange();
+  if (el.__quill) {
+    const quill = el.__quill;
+    const len = quill.getLength();
+    quill.setSelection(len, 0);
+    quill.focus();
+    saved = { type: 'quill', quill, range: { index: len, length: 0 } };
+  } else {
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    const sel = window.getSelection();
+    sel.removeAllRanges();
+    sel.addRange(range);
+    el.focus();
+    saved = { type: 'dom', range: range.cloneRange() };
+  }
 }

--- a/src/utils/quillSetup.js
+++ b/src/utils/quillSetup.js
@@ -1,0 +1,13 @@
+export function initQuillEditor(element) {
+  if (!window.Quill || !element) return null;
+  if (element.__quill) return element.__quill;
+  const placeholder = element.getAttribute('data-placeholder') || '';
+  const quill = new Quill(element, {
+    theme: 'snow',
+    placeholder,
+    modules: { toolbar: false }
+  });
+  quill.root.classList.add('editor');
+  return quill;
+}
+

--- a/src/utils/richText.js
+++ b/src/utils/richText.js
@@ -1,23 +1,47 @@
-import { restoreSelection, saveSelection } from './caret.js';
+import { initQuillEditor } from './quillSetup.js';
+import { saveSelection, restoreSelection } from './caret.js';
+
+function updateToolbar(quill) {
+  const toolbar = quill.root
+    .closest('.comment-form, #post-creation-form')
+    ?.querySelector('.toolbar');
+  if (!toolbar) return;
+  toolbar.querySelectorAll('button').forEach(btn => {
+    const cmd = btn.getAttribute('data-cmd');
+    if (!cmd || cmd === 'link') return;
+    const active = quill.getFormat()[cmd] || false;
+    btn.classList.toggle('active', !!active);
+  });
+}
 
 export function initRichText() {
- $(document).on('keyup mouseup input focus touchend', '.editor', function () {
-    ensureCursor(this);
-    saveSelection();
-    updateToolbar(this);
+  document.querySelectorAll('.editor').forEach(el => {
+    const quill = initQuillEditor(el);
+    if (quill) {
+      quill.on('selection-change', () => {
+        updateToolbar(quill);
+        saveSelection();
+      });
+      quill.on('text-change', () => {
+        updateToolbar(quill);
+        saveSelection();
+      });
+    }
   });
-  $(document).on('click', '.toolbar button', function (e) {
+
+  document.addEventListener('click', function (e) {
+    const btn = e.target.closest('.toolbar button');
+    if (!btn) return;
     e.preventDefault();
-    const cmd = $(this).data('cmd');
-    const editor = $(this)
-      .closest('.comment-form, #post-creation-form')
-      .find('.editor')[0];
-    if (!editor) return;
-   
-    editor.focus();
-    ensureCursor(editor);
-    restoreSelection(editor);
-   
+    const cmd = btn.getAttribute('data-cmd');
+    const container = btn.closest('.comment-form, #post-creation-form');
+    const quillContainer = container?.querySelector('.ql-container');
+    const quill = quillContainer ? quillContainer.__quill : null;
+    if (!quill) return;
+
+    quill.focus();
+    restoreSelection(quill.root);
+
     if (cmd === 'link') {
       let url = prompt('Enter URL');
       if (url) {
@@ -25,165 +49,13 @@ export function initRichText() {
         if (!/^https?:\/\//i.test(url)) {
           url = `https://${url}`;
         }
-        applyFormat('link', editor, url);
+        quill.format('link', url);
       }
     } else {
-      applyFormat(cmd, editor);
+      const current = quill.getFormat()[cmd];
+      quill.format(cmd, !current);
     }
-    updateToolbar(editor);
+    updateToolbar(quill);
     saveSelection();
   });
 }
-
-function ensureCursor(editor) {
-  const text = editor.textContent.replace(/\u200B/g, '');
-  if (!text) {
-    editor.innerHTML = '\u200B';
-    const range = document.createRange();
-    range.setStart(editor.firstChild, 1);
-    range.collapse(true);
-    const sel = window.getSelection();
-    sel.removeAllRanges();
-    sel.addRange(range);
-  }
-}
-
-// function applyFormat(cmd, editor, value) {
-//   const isStyle = cmd === 'bold' || cmd === 'italic' || cmd === 'underline';
-//   const isEmpty = editor.textContent.replace(/\u200B/g, '').trim() === '';
-
-//   if (isStyle && isEmpty) {
-//     const tag =
-//       cmd === 'bold' ? 'strong' : cmd === 'italic' ? 'em' : 'u';
-//     document.execCommand('insertHTML', false, `<${tag}>\u200B</${tag}>`);
-//     const node = editor.querySelector(`${tag}`);
-//     if (node && node.firstChild) {
-//       const range = document.createRange();
-//       range.setStart(node.firstChild, 1);
-//       range.collapse(true);
-//       const sel = window.getSelection();
-//       sel.removeAllRanges();
-//       sel.addRange(range);
-//     }
-//   } else if (cmd === 'link') {
-//     document.execCommand('createLink', false, value);
-//   } else {
-//     document.execCommand(cmd, false, null);
-//   }
-// }
-
-
-
-function applyFormat(cmd, editor, value) {
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0) return;
-  const range = sel.getRangeAt(0);
-  const isStyle = cmd === 'bold' || cmd === 'italic' || cmd === 'underline';
-
-  let tag;
-  if (isStyle) {
-    tag = cmd === 'bold' ? 'strong' : cmd === 'italic' ? 'em' : 'u';
-  } else if (cmd === 'link') {
-    tag = 'a';
-  } else {
-    return;
-  }
-
-  const wrapper = document.createElement(tag);
-  if (cmd === 'link') {
-    wrapper.setAttribute('href', value);
-    wrapper.setAttribute('target', '_blank');
-  }
-
-  if (range.collapsed) {
-    wrapper.textContent = '\u200B';
-    range.insertNode(wrapper);
-    range.setStart(wrapper.firstChild, 1);
-    range.collapse(true);
-    sel.removeAllRanges();
-    sel.addRange(range);
-    return;
-  }
-
-  const contents = range.extractContents();
-  wrapper.appendChild(contents);
-  range.insertNode(wrapper);
-  range.selectNodeContents(wrapper);
-  range.collapse(false);
-  sel.removeAllRanges();
-  sel.addRange(range);
-}
-
-
-function updateToolbar(editor) {
-  const toolbar = $(editor)
-    .closest('.comment-form, #post-creation-form')
-    .find('.toolbar');
-  toolbar.find('button').each(function () {
-    const cmd = $(this).data('cmd');
-    if (!cmd || cmd === 'link') return;
-    $(this).toggleClass('active', isFormatActive(cmd, editor));
-  });
-}
-
-function isFormatActive(cmd, editor) {
-  const sel = window.getSelection();
-  if (!sel || sel.rangeCount === 0) return false;
-  let node = sel.getRangeAt(0).startContainer;
-  while (node && node !== editor) {
-    const name = node.nodeName;
-    if (cmd === 'bold' && name === 'STRONG') return true;
-    if (cmd === 'italic' && name === 'EM') return true;
-    if (cmd === 'underline' && name === 'U') return true;
-    node = node.parentNode;
-  }
-  return false;
-}
-
-
-// $(document).on('input', '.editor', function () {
-//   const html = this.innerHTML.trim().toLowerCase();
-//   const hasFormat = this.querySelector('strong, em, u, a');
-//   if (html === '<br>' || html === '<div><br></div>' || (!hasFormat && this.textContent.trim() === '')) {
-//     this.innerHTML = '';
-//     const range = document.createRange();
-//     range.selectNodeContents(this);
-//     range.collapse(false);
-//     const sel = window.getSelection();
-//     sel.removeAllRanges();
-//     sel.addRange(range);
-//   }
-//   updateToolbar(this);
-//   saveSelection();
-// });
-$(document).on('input', '.editor', function () {
-  // Remove leading zero-width space if present
-  if (this.firstChild && this.firstChild.nodeType === 3 && this.firstChild.nodeValue.startsWith('\u200B')) {
-    const sel = window.getSelection();
-    let offset = null;
-    if (sel && sel.rangeCount && sel.getRangeAt(0).startContainer === this.firstChild) {
-      offset = sel.getRangeAt(0).startOffset;
-    }
-    this.firstChild.nodeValue = this.firstChild.nodeValue.replace(/^\u200B/, '');
-    if (offset !== null) {
-      const range = document.createRange();
-      range.setStart(this.firstChild, Math.max(0, offset - 1));
-      range.collapse(true);
-      sel.removeAllRanges();
-      sel.addRange(range);
-    }
-  }
-  const html = this.innerHTML.trim().toLowerCase();
-  const hasFormat = this.querySelector('strong, em, u, a');
-  if (html === '<br>' || html === '<div><br></div>' || (!hasFormat && this.textContent.trim() === '')) {
-    this.innerHTML = '';
-    const range = document.createRange();
-    range.selectNodeContents(this);
-    range.collapse(false);
-    const sel = window.getSelection();
-    sel.removeAllRanges();
-    sel.addRange(range);
-  }
-  updateToolbar(this);
-  saveSelection();
-});


### PR DESCRIPTION
## Summary
- include Quill JS CDN scripts
- initialize Quill via helper
- rewrite rich text utilities for Quill
- update comment form insertion logic
- adjust caret utilities and emoji insertion
- support Quill in modal helpers and post actions
- tweak editor styles

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_686df4d97894832182d54bdbdc912b13