### PR TITLE
Fix emoji insertion position

### DIFF
--- a/src/ui/emoji.js
+++ b/src/ui/emoji.js
@@ -151,8 +151,10 @@ export function initEmojiHandlers() {
 }
 
 function insertEmoji(editor, emoji) {
-  editor.focus();
+  // restore the previously saved selection **before** focusing the editor
+  // so the focus event doesn't overwrite the saved range
   restoreSelection(editor);
+  editor.focus();
   const sel = window.getSelection();
   if (!sel || sel.rangeCount === 0) return;
   const range = sel.getRangeAt(0);


### PR DESCRIPTION
## Summary
- ensure emoji is inserted at saved caret location

## Testing
- `npm test`
- `npm run lint` *(fails: Cannot find module 'globals')*

------
https://chatgpt.com/codex/tasks/task_b_6874ddaccba083219dde0b6de2aa7f0f